### PR TITLE
ARCH-1804 - Update default login value

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ jobs:
       - name: Update deployment board with Defaults
         id: defaults
         continue-on-error: true                             # Setting to true so the job doesn't fail if updating the board fails.
-        uses: im-open/update-deployment-board@v1.5.4        # You may also reference just the major or major.minor version
+        uses: im-open/update-deployment-board@v1.5.5        # You may also reference just the major or major.minor version
         with:
           github-token: ${{ secrets.GITHUB_TOKEN}}          # If a different token is used, update github-login with the corresponding account
           environment: 'QA'
@@ -123,7 +123,7 @@ jobs:
       - name: Update deployment board with all values provided
         id: provided
         continue-on-error: true                             # Setting to true so the job doesn't fail if updating the board fails.
-        uses: im-open/update-deployment-board@v1.5.4
+        uses: im-open/update-deployment-board@v1.5.5
         with:
           github-token: ${{ secrets.BOT_TOKEN}}             # Since a different token is used, the github-login should be set to the corresponding acct
           github-login: 'my-bot'

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,6 @@ inputs:
   github-login:
     description: 'The login associated with the github-token.  Defaults to github-actions'
     required: true
-    default: 'github-actions'
   environment:
     description: 'The environment the branch, tag or SHA was deployed to'
     required: true


### PR DESCRIPTION
# Summary of PR changes

Remove the default action value for github login since it has the correct default in code.

Tested the cleanup workflow [here](https://github.com/im-enrollment/underwriting/actions/runs/4408929026/jobs/7724572165).  It used the same pattern for the default login so fixing it the same way as the other action should do the trick.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
